### PR TITLE
Clicking on the tags in the log view will add them to the tag dropdown.

### DIFF
--- a/amon/web/templates/logs.html
+++ b/amon/web/templates/logs.html
@@ -126,6 +126,10 @@ Logs
 
         return true; // ensure form still submits
     });
+        $(".tag").click(function(e){
+                $('#tags-select option[value="' + $(this).text() +'"]').attr('selected','selected');
+                $('#tags-select').trigger('liszt:updated');
+        });    
 
 	
 </script>


### PR DESCRIPTION
I feel like clicking on the tag spans should add them to the tag dropdown, it makes it much easier to select relevant tags just by clicking on them.
