### PR TITLE
amon and amond uses the python interpreter defined by the environment

### DIFF
--- a/contrib/amon/amon
+++ b/contrib/amon/amon
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 ### BEGIN INIT INFO
 # Provides:          amond
 # Default-Start:     2 3 4 5

--- a/contrib/amon/amond
+++ b/contrib/amon/amond
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 ### BEGIN INIT INFO
 # Provides:          amond
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
Rather than relying on python being installed in /usr/bin, let the environment define what python to use.
