### PR TITLE
Fixed undefined $INSTALL_URL causing the installer to fail on Mac OSX...

### DIFF
--- a/installers/installer
+++ b/installers/installer
@@ -43,6 +43,7 @@ elif file_exists /etc/system-release ; then
 # Mac OS
 elif [ "$(uname -s)" == "Darwin" ]; then
     DISTRO='mac'
+	INSTALL_URL="http://install.amon.cx/"
 	curl "$INSTALL_URL"macos -o macos_installer
 	sudo bash macos_installer $VERSION
 	rm -rf macos_installer


### PR DESCRIPTION
...with the error `macos_installer: No such file or directory`.
