### PR TITLE
Making the calendar easier on the eye.

### DIFF
--- a/amon/web/media/sass/screen.sass
+++ b/amon/web/media/sass/screen.sass
@@ -622,4 +622,6 @@ ul.pagination
     &:hover
       color: #5E0000  
 
-
+// Calender
+.ui-datepicker .ui-widget-content
+  border: 2px solid #D2D2D2;


### PR DESCRIPTION
Right now is really hard to actually see the calendar borders

Currently it looks like this:
![Before](https://img.skitch.com/20120309-m42hjrf9ebwx33kudaap5mafp1.jpg)

The proposed change is:
![After](https://img.skitch.com/20120309-8g61ji1s58q6hb215puk4c51su.jpg)

Not really sure about the sass, never touch sass before and I did this on the fly.
