### PR TITLE
Remove unneeded quotation from cd ~/amonone

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,7 @@ hash git >/dev/null && /usr/bin/env git clone https://github.com/martinrusev/amo
   echo "git not installed"
   exit
 }
-	cd "~/amonone"
+	cd ~/amonone
 
 	sudo python setup.py install # Install Amon and all the dependecies
 	python generate_config.py # Generate the configuration file


### PR DESCRIPTION
The quotation causes cd to return "No such file or directory"
on Ubuntu 13.04. A static directory should not require quotation marks.
