### PR TITLE
Fixing pidstat output for international locale

### DIFF
--- a/amonone/core/collector/collector.py
+++ b/amonone/core/collector/collector.py
@@ -281,11 +281,11 @@ class ProcessInfoCollector(object):
 				command = line.split()
 				data_dict = dict(zip(header, command))
 				
-				process_memory_mb = float(self.total_memory/100) * float(data_dict["%MEM"]) # Convert the % in MB
+				process_memory_mb = float(self.total_memory/100) * float(data_dict["%MEM"].replace(",",".")) # Convert the % in MB
 				memory = "{0:.3}".format(process_memory_mb)
 				memory = memory.replace(",", ".")
 
-				cpu = "{0:.2f}".format(float(data_dict["%CPU"]))
+				cpu = "{0:.2f}".format(float(data_dict["%CPU"].replace(",",".")))
 				cpu = cpu.replace(",", ".")
 				
 				command = data_dict["Command"]


### PR DESCRIPTION
Replacing "," with "." will work for locale that use comma as a decimal separator.
