### PR TITLE
Fix get table data from plugin

### DIFF
--- a/amon/apps/plugins/models.py
+++ b/amon/apps/plugins/models.py
@@ -590,7 +590,7 @@ class PluginModel(BaseModel):
 
             if keys:
                 result['header'] = keys
-                result['data'] = query
+                result['data'] = [element for element in query]
 
         return result
 


### PR DESCRIPTION
- Pymongo's cursor query can be readed once.
- PSQL's plugin data was lost somewhere in the proces due to that fact. I guess it should happen to the other plugins as well...

Setting the query result as a list should prevent this bug.