### PR TITLE
add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ remotefiles/
 dev_settings.py
 *.log
 *.vagrant
+mongodb
+caddy

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,8 @@
+http://example.com {
+    tls self_signed
+    root /srv
+    proxy / http://amon:8000 {
+        transparent
+        except /static
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM frolvlad/alpine-python3
+
+# Install all required dependencies
+RUN apk add --no-cache gcc yaml-dev libev-dev git gcc g++ make libffi-dev openssl-dev
+RUN apk add --no-cache python3-dev
+
+# Create the directories where you are going to store the configs, logs and Amon itself
+RUN mkdir -p /opt/amon
+RUN mkdir -p /var/log/amon
+RUN mkdir -p /etc/opt/amon
+
+# Clone repo into app directory
+RUN git clone https://github.com/amonapp/amon.git /opt/amon
+
+# Install Python deps
+RUN pip install -r /opt/amon/requirements.txt
+
+# Setup Unicorn
+COPY gunicorn.conf /opt/amon/gunicorn.conf
+
+# Copy defaults and setup working directroy
+COPY amon-defaults.yml /etc/opt/amon/amon.yml
+WORKDIR /opt/amon
+
+# Run the database migrations and cron install tasks
+RUN python3 manage.py migrate
+RUN python3 manage.py installtasks
+
+# Setup external volumes
+VOLUME ["/opts/amon", "/var/log/amon", "/etc/opt/amon"]
+
+# Setup Ports
+EXPOSE 8000
+
+# Start webserver
+CMD gunicorn wsgi -c /opt/amon/gunicorn.conf

--- a/amon-defaults.yml
+++ b/amon-defaults.yml
@@ -1,0 +1,9 @@
+host: http://example.com
+mongo_uri: mongodb://mongodb:27017
+smtp:
+  host: smtp.mailgun.org 
+  port: 587
+  username: amon_alerts
+  password: amon_password
+  use_tls: true
+  sent_from: alerts@yourdomain.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '2'
+services:
+  caddy:
+    image: abiosoft/caddy
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "./Caddyfile:/etc/Caddyfile"
+      - "./caddy:/root/.caddy"
+      - "./amon/static:/srv/static"
+    links:
+      - "amon:amon"
+    depends_on:
+        - "amon"
+  mongodb:
+    image: "mongo"
+    restart: always
+    expose:
+      - "27017"
+    volumes:
+      - "./mongodb:/data/db:rw"
+  amon:
+    build: "."
+    restart: always
+    expose:
+      - "8000"
+    links:
+      - "mongodb:mongodb"
+    depends_on:
+      - "mongodb"


### PR DESCRIPTION
To use this you need to run `docker-compose up -d --build` in the repo directory.

This will setup caddy to proxy the static files, mongodb and the Amon process.

To change the domain used you'll need to edit the `Caddyfile` with your domain and make sure to add that mount point in the `docker-compose.yml` for `/etc/opt/amon/amon.yml`.

Closes https://github.com/amonapp/amon/issues/172