### PR TITLE
Fix 500 error when passing a float to range() refs #193

### DIFF
--- a/amon/apps/alerts/views/alerts.py
+++ b/amon/apps/alerts/views/alerts.py
@@ -215,7 +215,7 @@ def history_system(request, alert_id):
     
     on_page = 100
     if total > on_page:
-        total_pages = total/on_page
+        total_pages = total//on_page
     else:
         total_pages = 1
 


### PR DESCRIPTION
Refs: #193 
The alert history page failed to load for us due to a `float` being passed to `range`.

This fix is to ensure an int is passed to range so the alert history page loads